### PR TITLE
test: add milestone approval functionality to verifund tests

### DIFF
--- a/tests/verifund.test.ts
+++ b/tests/verifund.test.ts
@@ -138,4 +138,33 @@ describe("verifund tests", () => {
 
     expect(result.result).toBeErr(Cl.uint(0));
   });
+
+  it("should allow funders to approve milestones", () => {
+    const fund = simnet.callPublicFn(
+      "verifund",
+      "fund_campaign",
+      [Cl.uint(0), Cl.uint(20000)],
+      address2
+    );
+
+    expect(fund.events[0].event).toBe("stx_transfer_event");
+    expect(fund.events[0].data.amount).toBe("20000");
+
+    const approve = simnet.callPublicFn(
+      "verifund",
+      "approve-milestone",
+      [Cl.uint(0), Cl.uint(0)],
+      address2
+    );
+
+    expect(approve.result).toBeOk(Cl.bool(true));
+
+    const milestone = simnet.getMapEntry("verifund", "milestone_approvals", Cl.tuple({campaign_id: Cl.uint(0), milestone_index: Cl.uint(0)}));
+    expect(milestone).toBeSome(
+      Cl.tuple({
+        approvals: Cl.uint(20000),
+        voters: Cl.list([Cl.address(address2)])
+      })
+    );
+  });
 });


### PR DESCRIPTION
This pull request adds a new test case to the `verifund` test suite to ensure that funders can approve milestones. 

### New test case addition:
* [`tests/verifund.test.ts`](diffhunk://#diff-a1c36c1df62be2ecd889b605ba7d502a000ee30e91570b2982b30f0156d936a0R141-R169): Added a test case named `"should allow funders to approve milestones"` to verify the functionality of approving milestones, including checks for STX transfer events, approval results, and updates to the `milestone_approvals` map.